### PR TITLE
docs: require Calque in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ You decide how to turn your value into a string before creating a snapshot, givi
 ```elixir
 defmodule MyApp.GreetingTest do
   use ExUnit.Case, async: true
+
+  require Calque
+
   # Example using check/2
   test "renders a friendly greeting" do
     %{hello: "world", nums: [1, 2, 3, 4]}


### PR DESCRIPTION
Fix the example so it works out of the box